### PR TITLE
ant-build file in utils have a new name

### DIFF
--- a/dda-build.xml
+++ b/dda-build.xml
@@ -53,7 +53,7 @@
 			</then>
 			<else>
 				<echo message="Building DDIFtp-util" />
-				<ant inheritall="false" inheritrefs="false" antfile="${basedir}/../util/build.xml" target="jar" />
+				<ant inheritall="false" inheritrefs="false" antfile="${basedir}/../util/dda-build.xml" target="jar" />
 				<echo message="DDIFtp-util build" />
 			</else>
 		</if>


### PR DESCRIPTION
Got error when building the DDI editor, seems like util/build.xml should be util/dda-build.xml if i check in the util repo: https://github.com/DdiEditor/util